### PR TITLE
Fix users without server tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-node_modules
-.dev.vars
+.env*
+.dev.vars*
 .wrangler
+node_modules

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
 	"main": "src/server.js",
 	"scripts": {
 		"deploy": "wrangler deploy",
+		"deploy:staging": "wrangler deploy --env staging",
+		"deploy:production": "wrangler deploy --env production",
 		"fix": "biome check --write .",
 		"lint": "biome check .",
 		"register": "node src/register.js",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,6 @@
 	"main": "src/server.js",
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"deploy:staging": "wrangler deploy --env staging",
-		"deploy:production": "wrangler deploy --env production",
 		"fix": "biome check --write .",
 		"lint": "biome check .",
 		"register": "node src/register.js",

--- a/src/clip.js
+++ b/src/clip.js
@@ -4,6 +4,11 @@
 
 import puppeteer from '@cloudflare/puppeteer';
 
+/**
+ * Generates HTML content for a Discord message.
+ * @param {import('discord-api-types/v10').APIMessage} message - The Discord message object.
+ * @returns {string} - The generated HTML content.
+ */
 function generateHtml(message) {
 	const author = message.author;
 	const username = author.username;
@@ -142,6 +147,12 @@ function generateHtml(message) {
 	return htmlTemplate;
 }
 
+/**
+ * Generate a message screenshot from a Discord message.
+ * @param {import('discord-api-types/v10').APIMessage} message - The Discord message object.
+ * @param {*} env - The environment variables.
+ * @returns {Promise<Buffer>} - The screenshot image buffer.
+ */
 async function generateMessageScreenshot(message, env) {
 	let browser;
 	try {
@@ -164,6 +175,11 @@ async function generateMessageScreenshot(message, env) {
 	}
 }
 
+/**
+ * Generate a message clip from a Discord interaction.
+ * @param {import('discord-api-types/v10').APIInteraction} interaction - The Discord interaction object.
+ * @param {*} env - The environment variables.
+ */
 export async function generateMessageClip(interaction, env) {
 	const targetId = interaction.data.target_id;
 	const targetMessage = interaction.data.resolved.messages[targetId];

--- a/src/clip.js
+++ b/src/clip.js
@@ -13,8 +13,10 @@ function generateHtml(message) {
 	const author = message.author;
 	const username = author.username;
 	const avatarUrl = `https://cdn.discordapp.com/avatars/${author.id}/${author.avatar}.png`;
-	const serverTag = author.clan.tag;
-	const serverTagBadge = `https://cdn.discordapp.com/guild-tag-badges/${author.clan?.identity_guild_id}/${author.clan?.badge}.png`;
+	const serverTag = author.clan?.tag || '';
+	const serverTagBadge = author.clan
+		? `https://cdn.discordapp.com/guild-tag-badges/${author.clan.identity_guild_id}/${author.clan.badge}.png`
+		: '';
 	const messageContent = message.content;
 
 	// TODO: Use file later, don't hard code


### PR DESCRIPTION
## Description

Fixes an error that would happen when you clip a user without a server tag which causes the bot to error out and think indefinitely.

## Related Issues

<!-- List any related issues or pull requests that are being resolved or addressed by this pull request.

Example:
Closes #issue_number

Replace issue_number with the issue number to mark it -->

## Changes Made

### Documentation Improvements:

* Added JSDoc comments to the `generateHtml` function, explaining its purpose, parameters, and return type.
* Documented the `generateMessageScreenshot` function with JSDoc, providing details about its parameters and return type.
* Added JSDoc comments for the `generateMessageClip` function, describing its purpose and input parameters.

### Code Safety Enhancements:

* Updated the `generateHtml` function to safely handle optional `clan` properties using optional chaining and default values.

## Checklist

<!-- Please check off the following items before submitting your pull request: 

Example:
- [x] I have checked this box

Simply put an "x" between the brackets like here to check it -->

- [x] I have tested these changes thoroughly.
- [x] I have reviewed my code for any potential errors or issues.
- [x] I have followed the code style guidelines for this project.

## Additional Notes

<!-- Provide any additional information or notes that may be helpful in reviewing this pull request. -->