### PR TITLE
Fix browser rate limiting

### DIFF
--- a/src/clip.js
+++ b/src/clip.js
@@ -169,6 +169,8 @@ async function generateMessageScreenshot(message, env) {
 			optimizeForSpeed: true,
 		});
 
+		await browser.close();
+
 		return screenshot;
 	} catch (screenshotError) {
 		console.error(`Screenshot generation failed:`, screenshotError);

--- a/src/clip.js
+++ b/src/clip.js
@@ -156,27 +156,61 @@ function generateHtml(message) {
  * @returns {Promise<Buffer>} - The screenshot image buffer.
  */
 async function generateMessageScreenshot(message, env) {
+	// Pick random session from open sessions
+	let sessionId = await getRandomSession(env.BROWSER);
 	let browser;
-	try {
-		browser = await puppeteer.launch(env.BROWSER);
-		const page = await browser.newPage();
-
-		const html = generateHtml(message);
-
-		await page.setContent(html);
-
-		const screenshot = await page.screenshot({
-			optimizeForSpeed: true,
-		});
-
-		await browser.close();
-
-		return screenshot;
-	} catch (screenshotError) {
-		console.error(`Screenshot generation failed:`, screenshotError);
-		console.error(`Screenshot error type: ${screenshotError.constructor.name}`);
-		throw screenshotError;
+	if (sessionId) {
+		try {
+			browser = await puppeteer.connect(env.BROWSER, sessionId);
+		} catch (e) {
+			// another worker may have connected first
+			console.log(`Failed to connect to ${sessionId}. Error ${e}`);
+		}
 	}
+	if (!browser) {
+		// No open sessions, launch new session
+		browser = await puppeteer.launch(env.BROWSER);
+	}
+
+	sessionId = browser.sessionId(); // get current session id
+
+	// Generate the screenshot
+	const page = await browser.newPage();
+	const html = generateHtml(message);
+	await page.setContent(html);
+	const screenshot = await page.screenshot({
+		optimizeForSpeed: true,
+	});
+
+	// All work done, so free connection (IMPORTANT!)
+	browser.disconnect();
+
+	return screenshot;
+}
+
+/**
+ * Get a random session ID from the available sessions.
+ * @param {import("@cloudflare/puppeteer").BrowserWorker} endpoint
+ * @return {Promise<string|undefined>} - The session ID or undefined if no sessions are available.
+ * @see {@link https://developers.cloudflare.com/browser-rendering/workers-bindings/reuse-sessions/}
+ */
+async function getRandomSession(endpoint) {
+	const sessions = await puppeteer.sessions(endpoint);
+	console.log(`Sessions: ${JSON.stringify(sessions)}`);
+	const sessionsIds = sessions
+		.filter((v) => {
+			return !v.connectionId; // remove sessions with workers connected to them
+		})
+		.map((v) => {
+			return v.sessionId;
+		});
+	if (sessionsIds.length === 0) {
+		return;
+	}
+
+	const sessionId = sessionsIds[Math.floor(Math.random() * sessionsIds.length)];
+
+	return sessionId;
 }
 
 /**

--- a/src/clip.js
+++ b/src/clip.js
@@ -162,14 +162,19 @@ async function generateMessageScreenshot(message, env) {
 	if (sessionId) {
 		try {
 			browser = await puppeteer.connect(env.BROWSER, sessionId);
-		} catch (e) {
+		} catch (sessionError) {
 			// another worker may have connected first
-			console.log(`Failed to connect to ${sessionId}. Error ${e}`);
+			console.log(`Failed to connect to ${sessionId}. Error ${sessionError}`);
 		}
 	}
 	if (!browser) {
-		// No open sessions, launch new session
-		browser = await puppeteer.launch(env.BROWSER);
+		try {
+			// No open sessions, launch new session
+			browser = await puppeteer.launch(env.BROWSER);
+		} catch (browserError) {
+			console.error('Browser launch failed:', browserError);
+			throw browserError;
+		}
 	}
 
 	sessionId = browser.sessionId(); // get current session id

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,6 +17,9 @@
 	// 	"directory": "./public",
 	// 	"binding": "ASSETS"
 	// },
+	"limits": {
+		"cpu_ms": 10
+	},
 	"observability": {
 		"enabled": true
 	}


### PR DESCRIPTION
## Description

Addresses rate limiting issues from browser rendering. Browser time is more efficiently used by reusing sessions. In addition, there is reduced latency from using pre-existing browsers.

## Related Issues

<!-- List any related issues or pull requests that are being resolved or addressed by this pull request.

Example:
Closes #issue_number

Replace issue_number with the issue number to mark it -->

## Changes Made

### Improvements to browser session handling:

* [`src/clip.js`](diffhunk://#diff-b5e030574251591c2430745fe56c7a0a90739f7a6906c293625b2eefb9028943R159-R218): Enhanced the `generateMessageScreenshot` function to reuse existing browser sessions by introducing a new utility function, `getRandomSession`. This reduces the overhead of launching new browser instances when sessions are available. The function ensures that disconnected sessions are cleaned up after use.

### Configuration updates:

* [`wrangler.jsonc`](diffhunk://#diff-21d9afdd0ffc457d5e1566045b68c0ca0ecc57ea3e5f704ee22164133e940736R20-R22): Added a `limits` section to restrict the worker's CPU usage to 10 milliseconds, optimizing resource usage and preventing excessive CPU consumption.

## Checklist

<!-- Please check off the following items before submitting your pull request: 

Example:
- [x] I have checked this box

Simply put an "x" between the brackets like here to check it -->

- [x] I have tested these changes thoroughly.
- [x] I have reviewed my code for any potential errors or issues.
- [x] I have followed the code style guidelines for this project.

## Additional Notes

<!-- Provide any additional information or notes that may be helpful in reviewing this pull request. -->