### PR TITLE
Local development for browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1251,9 +1251,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "24.0.15",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.15.tgz",
-			"integrity": "sha512-oaeTSbCef7U/z7rDeJA138xpG3NuKc64/rZ2qmUFkFJmnMsAPaluIifqyWd8hSSMxyP9oie3dLAqYPblag9KgA==",
+			"version": "24.1.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+			"integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"fix": "biome check --write .",
 		"lint": "biome check .",
 		"register": "node src/register.js",
-		"start": "wrangler dev --remote",
+		"start": "wrangler dev",
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
 	"dependencies": {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
 	"name": "disclip",
 	"main": "src/server.js",
-	"compatibility_date": "2025-06-17",
+	"compatibility_date": "2025-07-24",
 	"compatibility_flags": ["nodejs_compat"],
 	"browser": {
 		"binding": "BROWSER"


### PR DESCRIPTION
## Description

Don't use remotes for browsers but do it locally instead. This should save browser hours since we're no longer using [Browser Rendering](https://developers.cloudflare.com/browser-rendering/) limit from Cloudflare

https://developers.cloudflare.com/changelog/2025-07-22-br-local-dev/

## Related Issues

<!-- List any related issues or pull requests that are being resolved or addressed by this pull request.

Example:
Closes #issue_number

Replace issue_number with the issue number to mark it -->

## Changes Made

This pull request includes two small changes to configuration files, focusing on updating the development environment setup and compatibility date.

* Updated the `start` script in `package.json` to use `wrangler dev` instead of `wrangler dev --remote`, simplifying the local development setup.
* Updated the `compatibility_date` in `wrangler.jsonc` to `2025-07-24`, likely to align with the latest compatibility requirements for the project.

## Checklist

<!-- Please check off the following items before submitting your pull request: 

Example:
- [x] I have checked this box

Simply put an "x" between the brackets like here to check it -->

- [x] I have tested these changes thoroughly.
- [x] I have reviewed my code for any potential errors or issues.
- [x] I have followed the code style guidelines for this project.

## Additional Notes

<!-- Provide any additional information or notes that may be helpful in reviewing this pull request. -->