### PR TITLE
Silent message clipping 

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -24,3 +24,20 @@ export const CLIP_COMMAND = {
 	],
 	type: ApplicationCommandType.Message,
 };
+
+/**
+ * Silent clip command that sends an ephemeral message.
+ * @type {import('discord-api-types/v10').RESTPostAPIApplicationCommandsJSONBody}
+ */
+export const SILENT_CLIP_COMMAND = {
+	name: 'Clip Message (silent)',
+	integration_types: [
+		ApplicationIntegrationType.GuildInstall,
+		ApplicationIntegrationType.UserInstall,
+	],
+	contexts: [
+		InteractionContextType.PrivateChannel,
+		InteractionContextType.Guild,
+	],
+	type: ApplicationCommandType.Message,
+};

--- a/src/register.js
+++ b/src/register.js
@@ -6,7 +6,7 @@
 
 import process from 'node:process';
 import dotenv from 'dotenv';
-import { CLIP_COMMAND } from './commands.js';
+import { CLIP_COMMAND, SILENT_CLIP_COMMAND } from './commands.js';
 
 dotenv.config({ path: '.dev.vars' });
 
@@ -34,7 +34,7 @@ const response = await fetch(url, {
 		Authorization: `Bot ${token}`,
 	},
 	method: 'PUT',
-	body: JSON.stringify([CLIP_COMMAND]),
+	body: JSON.stringify([CLIP_COMMAND, SILENT_CLIP_COMMAND]),
 });
 
 if (response.ok) {

--- a/src/server.js
+++ b/src/server.js
@@ -75,9 +75,7 @@ router.post('/interactions', async (request, env, ctx) => {
 				});
 			}
 			case SILENT_CLIP_COMMAND.name.toLowerCase(): {
-				ctx.waitUntil(
-					generateMessageClip(interaction, env),
-				);
+				ctx.waitUntil(generateMessageClip(interaction, env));
 
 				return new JsonResponse({
 					type: InteractionResponseType.DeferredChannelMessageWithSource,

--- a/src/server.js
+++ b/src/server.js
@@ -5,11 +5,12 @@
 import {
 	InteractionResponseType,
 	InteractionType,
+	MessageFlags,
 } from 'discord-api-types/v10';
 import { verifyKey } from 'discord-interactions';
 import { AutoRouter } from 'itty-router';
 import { generateMessageClip } from './clip.js';
-import { CLIP_COMMAND } from './commands.js';
+import { CLIP_COMMAND, SILENT_CLIP_COMMAND } from './commands.js';
 
 /**
  * @typedef {Object} Env
@@ -71,6 +72,18 @@ router.post('/interactions', async (request, env, ctx) => {
 
 				return new JsonResponse({
 					type: InteractionResponseType.DeferredChannelMessageWithSource,
+				});
+			}
+			case SILENT_CLIP_COMMAND.name.toLowerCase(): {
+				ctx.waitUntil(
+					generateMessageClip(interaction, env, { ephemeral: true }),
+				);
+
+				return new JsonResponse({
+					type: InteractionResponseType.DeferredChannelMessageWithSource,
+					data: {
+						flags: MessageFlags.Ephemeral,
+					},
 				});
 			}
 			default:

--- a/src/server.js
+++ b/src/server.js
@@ -76,7 +76,7 @@ router.post('/interactions', async (request, env, ctx) => {
 			}
 			case SILENT_CLIP_COMMAND.name.toLowerCase(): {
 				ctx.waitUntil(
-					generateMessageClip(interaction, env, { ephemeral: true }),
+					generateMessageClip(interaction, env),
 				);
 
 				return new JsonResponse({


### PR DESCRIPTION
Adds a new command to clip as an ephemeral message.

<img width="703" height="516" alt="image" src="https://github.com/user-attachments/assets/0a6d5539-d901-4166-ac5c-06f1a0d4c9fc" />
